### PR TITLE
update Google Cloud functions nodejs version

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -75,7 +75,7 @@ jobs:
           id: deploy-webhook
           run: >-
             gcloud functions deploy ${{ inputs.webhook_path }}
-            --runtime=nodejs18
+            --runtime=nodejs20
             --source=.
             --entry-point=webhook
             --set-secrets=APP_KEY=projects/${{ inputs.GCP_PROJECT_ID }}/secrets/unbreak_${{ inputs.env }}_app_key:latest


### PR DESCRIPTION
**Migrate functions to a newer runtime before the decommission dates.**

This PR migrates Google Cloud functions to a newer runtime from Node.js 18 to Node.js 20, before the
decommission dates.

See https://github.com/nearform/hub-draft-issues/issues/376