### PR TITLE
fix: grant id-token to the dev deploy so CD can start

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,10 @@ on:
       - master
   workflow_call:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy-app-dev:
     name: deploy the app - Dev


### PR DESCRIPTION
Closes #825

Every Continuous Delivery run fails at startup. `deploy-app.yml` asks for `id-token: write` to reach GCP, but `cd.yml` doesn't grant it, so GitHub rejects the file before anything runs.

Adds the block `production-deploy.yml` already has:

```yaml
permissions:
  id-token: write
  contents: read
```

Only verifiable once merged. Details in #825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)